### PR TITLE
feat/store_cache_on_hub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tokenizers==0.10.3
 sentencepiece==0.1.96
 streamlit==0.88.0
 iso_639==0.4.5
-datasets==1.15.1
+git+https://github.com/huggingface/datasets@1bd9b923b86660ec9c432533cf2b4fa08fee345c
 powerlaw==1.5
 numpy==1.19.5
 pandas==1.3.0
@@ -19,6 +19,7 @@ scikit_learn==0.24.2
 seaborn==0.11.2
 streamlit-aggrid
 numexpr==2.7.3
+huggingface_hub==0.5.1
 
 scikit-learn~=0.24.2
 scipy~=1.7.3


### PR DESCRIPTION
Now, run_data_measurements.py pushes the cache to a private hub dataset. Then, app.py looks for the cache dataset on the hub and clones it if necessary.