### PR TITLE
added reading of cache from the hub

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,13 +75,6 @@ LENGTH_FIELD = dataset_utils.LENGTH_FIELD
 _MIN_VOCAB_COUNT = 10
 _SHOW_TOP_N_WORDS = 10
 
-
-@st.cache(
-    hash_funcs={
-        dataset_statistics.DatasetStatisticsCacheClass: lambda dstats: dstats.cache_path
-    },
-    allow_output_mutation=True,
-)
 def load_or_prepare(ds_args, show_embeddings, use_cache=False):
     """
     Takes the dataset arguments from the GUI and uses them to load a dataset from the Hub or, if
@@ -127,12 +120,6 @@ def load_or_prepare(ds_args, show_embeddings, use_cache=False):
     dstats.load_or_prepare_zipf()
     return dstats
 
-@st.cache(
-    hash_funcs={
-        dataset_statistics.DatasetStatisticsCacheClass: lambda dstats: dstats.cache_path
-    },
-    allow_output_mutation=True,
-)
 def load_or_prepare_widgets(ds_args, show_embeddings, use_cache=False):
     """
     Loader specifically for the widgets used in the app.

--- a/data_measurements/dataset_statistics.py
+++ b/data_measurements/dataset_statistics.py
@@ -16,7 +16,6 @@ import json
 import logging
 import statistics
 import shutil
-import os
 from os import mkdir, getenv, stat, walk, listdir
 from os.path import exists, isdir, islink, getsize
 from os.path import join as pjoin

--- a/data_measurements/dataset_utils.py
+++ b/data_measurements/dataset_utils.py
@@ -20,7 +20,6 @@ import streamlit as st
 import pandas as pd
 from datasets import Dataset, get_dataset_infos, load_dataset, load_from_disk
 from huggingface_hub import list_datasets
-from tqdm import tqdm
 from pathlib import Path
 from dotenv import load_dotenv
 from os import getenv

--- a/data_measurements/dataset_utils.py
+++ b/data_measurements/dataset_utils.py
@@ -19,6 +19,16 @@ import streamlit as st
 
 import pandas as pd
 from datasets import Dataset, get_dataset_infos, load_dataset, load_from_disk
+from huggingface_hub import list_datasets
+from tqdm import tqdm
+from pathlib import Path
+from dotenv import load_dotenv
+from os import getenv
+
+if Path(".env").is_file():
+    load_dotenv(".env")
+
+HF_TOKEN = getenv("HF_TOKEN")
 
 # treating inf values as NaN as well
 pd.set_option("use_inf_as_na", True)
@@ -48,17 +58,14 @@ DEDUP_TOT = "dedup_total"
 TOT_WORDS = "total words"
 TOT_OPEN_WORDS = "total open words"
 
-_DATASET_LIST = [
-    "c4",
-    "squad",
-    "squad_v2",
-    "hate_speech18",
-    "hate_speech_offensive",
-    "glue",
-    "super_glue",
-    "wikitext",
-    "imdb",
-]
+_CACHE_DATASET_LIST = [dset_info.id for dset_info in list_datasets(author="datameasurements", use_auth_token=HF_TOKEN)]
+def cache_name_startswith(name):
+    for cache_name in _CACHE_DATASET_LIST:
+        if name != "" and cache_name.startswith("datameasurements/" + name + "_"):
+            return True
+    return False
+
+_DATASET_LIST = [dset_info.id for dset_info in filter(lambda dset_info: cache_name_startswith(dset_info.id), list_datasets())]
 
 _STREAMABLE_DATASET_LIST = [
     "c4",


### PR DESCRIPTION
This PR enables the pulling of caches from the datameasurements organization on the hub.

run_data_measurements.py will already push caches to the datameasurements organization on the hub. This PR enables the data measurements tool to load these caches from the hub.

Because we might compute 100's of caches, the data measurements space won't be able to hold all of the caches at once. I've implemented a function that deletes the oldest caches from the data measurements space if the cache_dir has more than 8 gigabytes of caches. These deleted caches will be re-downloaded from the hub if someone selects them in the space again.

Note: I haven't yet added to the datameasurements organization all of the caches for "squad", "squad_v2", "hate_speech18", "hate_speech_offensive", "glue", "super_glue", "wikitext", "imdb". I should probably do that before this PR is deployed. Does anyone have these caches handy, or should I just recompute all of them?