### PR TITLE
cleaned up hub pulling and pushing of cache

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,17 +154,16 @@ def load_or_prepare_widgets(ds_args, show_embeddings, show_perplexities, live=Tr
     if use_cache:
         logs.warning("Using cache")
     dstats = dataset_statistics.DatasetStatisticsCacheClass(CACHE_DIR, **ds_args, use_cache=use_cache)
-
     # Don't recalculate when we're live
     dstats.set_deployment(live)
-    # checks whether the cache_dir exists in deployment mode
-    # creates cache_dir if not and if in development mode
+
     if pull_cache_from_hub:
         logs.warning(dataset_utils.pull_cache_from_hub(dstats.cache_path, dstats.dataset_cache_dir))
 
+    # checks whether the cache_dir exists in deployment mode
+    # creates cache_dir if not and if in development mode
     cache_dir_exists = dstats.check_cache_dir()
     if cache_dir_exists:
-
         try:
             # We need to have the text_dset loaded for further load_or_prepare
             dstats.load_or_prepare_dataset()

--- a/app.py
+++ b/app.py
@@ -102,6 +102,9 @@ def load_or_prepare(ds_args, show_embeddings, show_perplexities, use_cache=False
     if use_cache:
         logs.warning("Using cache")
     dstats = dataset_statistics.DatasetStatisticsCacheClass(CACHE_DIR, **ds_args, use_cache=use_cache)
+    if pull_cache_from_hub:
+        logs.warning(dataset_utils.pull_cache_from_hub(dstats.cache_path, dstats.dataset_cache_dir))
+
     logs.warning("Loading dataset")
     dstats.load_or_prepare_dataset()
     logs.warning("Loading labels")
@@ -135,7 +138,7 @@ def load_or_prepare(ds_args, show_embeddings, show_perplexities, use_cache=False
     },
     allow_output_mutation=True,
 )
-def load_or_prepare_widgets(ds_args, show_embeddings, show_perplexities, live=True, use_cache=False):
+def load_or_prepare_widgets(ds_args, show_embeddings, show_perplexities, live=True, pull_cache_from_hub=False, use_cache=False):
     """
     Loader specifically for the widgets used in the app.
     Args:
@@ -151,12 +154,17 @@ def load_or_prepare_widgets(ds_args, show_embeddings, show_perplexities, live=Tr
     if use_cache:
         logs.warning("Using cache")
     dstats = dataset_statistics.DatasetStatisticsCacheClass(CACHE_DIR, **ds_args, use_cache=use_cache)
+
     # Don't recalculate when we're live
     dstats.set_deployment(live)
     # checks whether the cache_dir exists in deployment mode
     # creates cache_dir if not and if in development mode
+    if pull_cache_from_hub:
+        logs.warning(dataset_utils.pull_cache_from_hub(dstats.cache_path, dstats.dataset_cache_dir))
+
     cache_dir_exists = dstats.check_cache_dir()
     if cache_dir_exists:
+
         try:
             # We need to have the text_dset loaded for further load_or_prepare
             dstats.load_or_prepare_dataset()
@@ -256,8 +264,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--live", default=False, required=False, action="store_true", help="Flag to specify that this is not running live.")
+    parser.add_argument(
+        "--pull_cache_from_hub", default=False, required=False, action="store_true", help="Flag to specify whether to look in the hub for measurements caches. If you are using this option, you must have HUB_CACHE_ORGANIZATION=<the organization you've set up on the hub to store your cache> and HF_TOKEN=<your hf token> on separate lines in a file named .env at the root of this repo.")
     arguments = parser.parse_args()
     live = arguments.live
+    pull_cache_from_hub = arguments.pull_cache_from_hub
     # Sidebar description and selection
     ds_name_to_dict = dataset_utils.get_dataset_info_dicts()
     st.title("Data Measurements Tool")
@@ -278,7 +289,7 @@ def main():
         dataset_args_right = st_utils.sidebar_selection(ds_name_to_dict, " B")
         left_col, _, right_col = st.columns([10, 1, 10])
         dstats_left, cache_exists_left = load_or_prepare_widgets(
-            dataset_args_left, show_embeddings, show_perplexities, use_cache=use_cache
+            dataset_args_left, show_embeddings, show_perplexities, pull_cache_from_hub=pull_cache_from_hub, use_cache=use_cache
         )
         with left_col:
             if cache_exists_left:
@@ -287,7 +298,7 @@ def main():
                 st.markdown("### Missing pre-computed data measures!")
                 st.write(dataset_args_left)
         dstats_right, cache_exists_right = load_or_prepare_widgets(
-            dataset_args_right, show_embeddings, show_perplexities, use_cache=use_cache
+            dataset_args_right, show_embeddings, show_perplexities, pull_cache_from_hub=pull_cache_from_hub, use_cache=use_cache
         )
         with right_col:
             if cache_exists_right:
@@ -298,7 +309,7 @@ def main():
     else:
         logs.warning("Using Single Dataset Mode")
         dataset_args = st_utils.sidebar_selection(ds_name_to_dict, "")
-        dstats, cache_exists = load_or_prepare_widgets(dataset_args, show_embeddings, show_perplexities, live=live, use_cache=use_cache)
+        dstats, cache_exists = load_or_prepare_widgets(dataset_args, show_embeddings, show_perplexities, live=live, pull_cache_from_hub=pull_cache_from_hub, use_cache=use_cache)
         if cache_exists:
             show_column(dstats, ds_name_to_dict, show_embeddings, show_perplexities, "")
         else:

--- a/data_measurements/dataset_statistics.py
+++ b/data_measurements/dataset_statistics.py
@@ -32,7 +32,6 @@ from data_measurements.npmi.npmi import nPMI
 # import evaluate
 from data_measurements.zipf import zipf
 from datasets import load_from_disk, load_metric
-from huggingface_hub import Repository, list_datasets
 from nltk.corpus import stopwords
 from os import mkdir, getenv
 from os.path import exists, isdir
@@ -44,14 +43,6 @@ from utils.dataset_utils import (CNT, EMBEDDING_FIELD, LENGTH_FIELD,
                                  TEXT_NAN_CNT, TOKENIZED_FIELD, TOT_OPEN_WORDS,
                                  TOT_WORDS, VOCAB, WORD, load_truncated_dataset)
 
-
-# from dotenv import load_dotenv
-
-
-# if Path(".env").is_file():
-#    load_dotenv(".env")
-
-HF_TOKEN = getenv("HF_TOKEN")
 
 pd.options.display.float_format = "{:,.3f}".format
 
@@ -270,21 +261,6 @@ class DatasetStatisticsCacheClass:
         # Things that get defined later.
         self.fig_tok_length_png = None
         self.length_stats_dict = None
-
-        # Try to pull from the hub to see if the cache already exists.
-        try:
-            if not isdir(self.cache_path) and self.dataset_cache_dir in [
-                dataset_info.id.split("/")[-1] for dataset_info in
-                list_datasets(author="datameasurements",
-                              use_auth_token=HF_TOKEN)]:
-                repo = Repository(local_dir=self.cache_path,
-                                  clone_from="datameasurements/" + self.dataset_cache_dir,
-                                  repo_type="dataset", use_auth_token=HF_TOKEN)
-            else:
-                logs.warning("Cannot find cached repo on the hub.")
-        except Exception as e:
-            print(e)
-            logs.warning("Cannot load cached repo on the hub.")
 
         # Cache files not needed for UI
         self.dset_fid = pjoin(self.cache_path, "base_dset")

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,6 @@ scikit-learn~=0.24.2
 scipy~=1.7.3
 tqdm~=4.62.3
 pyarrow~=6.0.1
-
+python-dotenv==0.20.0
+json2html==1.3.0
 matplotlib~=3.5.0

--- a/run_data_measurements.py
+++ b/run_data_measurements.py
@@ -1,7 +1,6 @@
 import argparse
 import json
-# TODO(Tristan): Fix this dependency
-# from dotenv import load_dotenv
+from dotenv import load_dotenv
 import plotly
 import shutil
 import smtplib
@@ -12,18 +11,9 @@ from data_measurements import dataset_statistics
 from data_measurements.zipf import zipf
 from huggingface_hub import create_repo, Repository, hf_api
 from os import getenv
-from os.path import join as pjoin
+from os.path import exists, join as pjoin
 from pathlib import Path
 from utils import dataset_utils
-
-port = 465  # For SSL
-
-# if Path(".env").is_file():
-#    load_dotenv(".env")
-
-# TODO: Explain that this needs to be done/how to do it.
-HF_TOKEN = getenv("HF_TOKEN")
-EMAIL_PASSWORD = getenv("EMAIL_PASSWORD")
 
 
 def load_or_prepare_widgets(ds_args, show_embeddings=False,
@@ -294,18 +284,18 @@ def main():
         default=False,
         required=False,
         action="store_true",
-        help="Whether to overwrite a previous cache for these same arguments (Optional)",
+        help="Whether to overwrite a previous local cache for these same arguments (Optional)",
     )
     parser.add_argument(
         "--email",
         default=None,
-        help="An email that recieves a message about whether the computation was successful. If email is not None, then you must have EMAIL_PASSWORD for the sender email (data.measurements.tool@gmail.com) in a file named .env at the root of this repo.")
+        help="An email that recieves a message about whether the computation was successful. If email is not None, then you must have EMAIL_PASSWORD=<your email password> for the sender email (data.measurements.tool@gmail.com) in a file named .env at the root of this repo.")
     parser.add_argument(
         "--push_cache_to_hub",
         default=False,
         required=False,
         action="store_true",
-        help="Whether to push the cache to the datameasurements organization on the hub. If you are using this option, you must have HF_TOKEN in a file named .env at the root of this repo.",
+        help="Whether to push the cache to an organization on the hub. If you are using this option, you must have HUB_CACHE_ORGANIZATION=<the organization you've set up on the hub to store your cache> and HF_TOKEN=<your hf token> on separate lines in a file named .env at the root of this repo.",
     )
     parser.add_argument("--prepare_GUI_data", default=False, required=False,
                         action="store_true",
@@ -319,7 +309,11 @@ def main():
     print(args)
     # run_data_measurements.py -d hate_speech18 -c default -s train -f text -w npmi
     if args.email is not None:
+        if Path(".env").is_file():
+            load_dotenv(".env")
+        EMAIL_PASSWORD = getenv("EMAIL_PASSWORD")
         context = ssl.create_default_context()
+        port = 465
         server = smtplib.SMTP_SSL("smtp.gmail.com", port, context=context)
         server.login("data.measurements.tool@gmail.com", EMAIL_PASSWORD)
 
@@ -329,62 +323,22 @@ def main():
 
     dataset_cache_dir = f"{args.dataset}_{args.config}_{args.split}_{args.feature}"
     cache_path = args.out_dir + "/" + dataset_cache_dir
+
+    # Initialize the repository
+    if exists(cache_path):
+        if args.overwrite_previous:
+            shutil.rmtree(cache_path)
+        else:
+            raise OSError("Cache for this dataset already exists. Delete it or use the --overwrite_previous argument.")
     dataset_utils.make_cache_path(cache_path)
 
     dataset_arguments_message = f"dataset: {args.dataset}, config: {args.config}, split: {args.split}, feature: {args.feature}, label field: {args.label_field}, label names: {args.label_names}"
-    # Prepare some of the messages we use in different if-else/try-except cases later.
-    not_computing_message = "As you specified, not overwriting the previous dataset cache."
-    # Initialize the repository
+
     if args.push_cache_to_hub:
-        try:
-            create_repo(dataset_cache_dir, organization="datameasurements",
-                        repo_type="dataset", private=True, token=HF_TOKEN)
-        # Error because the repo is already created
-        except hf_api.HTTPError as err:
-            if err.args[
-                0] == "409 Client Error: Conflict for url: https://huggingface.co/api/repos/create - You already created this dataset repo":
-                already_computed_message = f"Already created a repo for the dataset with arguments: {dataset_arguments_message}."
-            else:
-                already_computed_message = " - ".join(err.args)
-            print(already_computed_message)
-            if args.overwrite_previous:
-                print("As you specified, overwriting previous cache.")
-            else:
-                print(not_computing_message)
-                if args.email is not None:
-                    server.sendmail("data.measurements.tool@gmail.com",
-                                    args.email,
-                                    "Subject: Data Measurments not Computed\n\n" + already_computed_message + " " + not_computing_message)
-                return
-        # Some other error that we do not anticipate.
-        except Exception as err:
-            error_message = f"There is an error on the hub that is preventing repo creation. Details: " + " - ".join(
-                err.args)
-            print(error_message)
-            print(not_computing_message)
-            if args.email is not None:
-                server.sendmail("data.measurements.tool@gmail.com", args.email,
-                                "Subject: Data Measurments not Computed\n\n" + error_message + "\n" + not_computing_message)
-            return
+        repo = dataset_utils.initialize_cache_hub_repo(cache_path, dataset_cache_dir)
+
     # Run the measurements.
     try:
-        if args.push_cache_to_hub:
-            # TODO: This breaks if the cache path exists and it isn't a git repository (such as when someone has dev'ed locally and is moving to the online repo)
-            # A solution would be something like this, although probably the .git directory
-            # would also need to be checked to see if it's the *right* git repo.
-            """
-            n = 1
-            new_cache_path = cache_path
-            while os.path.exists(new_cache_path) and not os.path.exists(new_cache_path + "/.git"):
-               print("Trying to clone from repo to %s, but it exists already and is not a git repo." % new_cache_path)
-               new_cache_path = cache_path + "." + str(n)
-               print("Trying to clone to %s instead" % new_cache_path)
-               n += 1
-            """
-            repo = Repository(local_dir=cache_path,
-                              clone_from="datameasurements/" + dataset_cache_dir,
-                              repo_type="dataset", use_auth_token=HF_TOKEN)
-            repo.lfs_track(["*.feather"])
         get_text_label_df(
             args.dataset,
             args.config,
@@ -404,7 +358,7 @@ def main():
         print(computed_message)
         print()
         if args.email is not None:
-            computed_message += "\nYou can return to the data measurements tool to view them at https://huggingface.co/spaces/datameasurements/data-measurements-tool"
+            computed_message += "\nYou can return to the data measurements tool to view them."
             server.sendmail("data.measurements.tool@gmail.com", args.email,
                             "Subject: Data Measurements Computed!\n\n" + computed_message)
             print(computed_message)
@@ -428,28 +382,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-    # Deleted this because of merge conflict -- saving here in case it should not have been deleted.
-    # try:
-    #    create_repo(dataset_cache_dir, organization="datameasurements", repo_type="dataset", private=True, token=HF_TOKEN)
-    # except hf_api.HTTPError as err:
-    #    if err.args[0] == "409 Client Error: Conflict for url: https://huggingface.co/api/repos/create - You already created this dataset repo":
-    #        error_message = f"Already created a repo for the dataset with arguments: {dataset_arguments_message}."
-    #    else:
-    #        error_message = " - ".join(err.args)
-    #    print(error_message)
-    #    if args.overwrite_previous:
-    #        print("Overwriting precious cache.")
-    ## May never hit this.
-    # except Exception as err:
-    #    error_message = f"There is an error on the hub that is preventing repo creation. Details: " + " - ".join(err.args)
-    #    not_computing_message = "Not computing the dataset cache."
-    #    print(error_message)
-    #    print(not_computing_message)
-    #    if args.email is not None:
-    #        server.sendmail("data.measurements.tool@gmail.com", args.email, "Subject: Data Measurments not Computed\n\n" + error_message + "\n" + not_computing_message)
-    #    return
-    # try:
-    #    cache_path = args.out_dir + "/" + dataset_cache_dir
-    #    repo = Repository(local_dir=cache_path, clone_from="datameasurements/" + dataset_cache_dir, repo_type="dataset", use_auth_token=HF_TOKEN)
-    #    repo.lfs_track(["*.feather"])

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -15,7 +15,7 @@
 import json
 import os
 from dataclasses import asdict
-from os.path import exists, isdir
+from os.path import exists, isdir, join as pjoin
 import plotly
 import pyarrow.feather as feather
 import pandas as pd


### PR DESCRIPTION
Cleaned up how run_data_measurements.py and app.py do pulling and pushing of cache to the hub.

Now, you can do this if you want to push a cache to the hub, overwriting the local cache that you have with the version that has a .git folder:
`python3 run_data_measurements.py --dataset="hate_speech18" --config="default" --split="train" --label_field="label" --feature="text" --push_cache_to_hub --overwrite_previous`

You can also do this if you want the app to try to pull caches from the hub
`streamlit run app.py -- --live --pull_cache_from_hub`

Documentation for how to set the organization you are pulling/pushing cache to, and the relevant access token, is provided in the documentation for the argparse commands.

lmk what you think!