### PR TITLE
Patching text duplicates not being newly computed issue.

### DIFF
--- a/data_measurements/text_duplicates/text_duplicates.py
+++ b/data_measurements/text_duplicates/text_duplicates.py
@@ -34,7 +34,11 @@ class DMTHelper:
             dstats.load_or_prepare_text_dset()
             self.dset = dstats.text_dset
         self.use_cache = dstats.use_cache
-        self.duplicates_results = dstats.duplicates_results
+        # Note: This is None as it can be called different times with different
+        # settings, and so we want fresh results each time. With the evaluate
+        # integration, results are different depending on whether
+        # list_duplicates is set.
+        self.duplicates_results = None
         self.cache_dir = dstats.dataset_cache_dir
         self.save = save
         self.load_only = load_only


### PR DESCRIPTION
When we integrated with `evaluate`, we ended up with `duplicates_results` having 2 different forms: One with duplicates listed, one without (following the `evaluate` logic). This ended up breaking things because when we first got duplicates results without the listed duplicates, but then later wanted duplicates listed, the `duplicates_results` had already been computed and so wasn't computed again. This meant we couldn't get the list of duplicates (much less cache/save them). This fixes that by making sure `duplicates_results` is None each time the duplicates calculation is requested.