### PR TITLE
When no labels are present, handle it gracefully.

### DIFF
--- a/data_measurements/dataset_statistics.py
+++ b/data_measurements/dataset_statistics.py
@@ -344,11 +344,14 @@ class DatasetStatisticsCacheClass:
         or else uses what's available in the cache.
         Currently supports Datasets with just one label column.
         """
-        label_obj = labels.DMTHelper(self, load_only=load_only, save=self.save)
-        label_obj.run_DMT_processing()
-        self.fig_labels = label_obj.fig_labels
-        self.label_results = label_obj.label_results
-        self.label_files = label_obj.get_label_filenames()
+        if self.label_field not in self.dset:
+            logs.warning("No label field. Not computing label statistics.")
+        else:
+            label_obj = labels.DMTHelper(self, load_only=load_only, save=self.save)
+            label_obj.run_DMT_processing()
+            self.fig_labels = label_obj.fig_labels
+            self.label_results = label_obj.label_results
+            self.label_files = label_obj.get_label_filenames()
 
     # Get vocab with word counts
     def load_or_prepare_vocab(self, load_only=False):

--- a/data_measurements/labels/labels.py
+++ b/data_measurements/labels/labels.py
@@ -61,7 +61,7 @@ def make_label_fig(label_results, chart_type="pie"):
             # which breaks the assumption that
             # the number of label_names == the number of label_sums.
             # This handles that case, assuming it will happen in other datasets.
-            if len(label_names) != label(label_sums):
+            if len(label_names) != len(label_sums):
                 logs.warning("Can't make a figure with the given label names: "
                              "We don't have the right amount of label types "
                              "to apply them to!")

--- a/data_measurements/labels/labels.py
+++ b/data_measurements/labels/labels.py
@@ -57,6 +57,15 @@ def make_label_fig(label_results, chart_type="pie"):
             if chart_type != "pie":
                 logs.info("Oops! Don't have that chart-type implemented.")
                 logs.info("Making the default pie chart")
+            # IMDB - unsupervised has a labels column where all values are -1,
+            # which breaks the assumption that
+            # the number of label_names == the number of label_sums.
+            # This handles that case, assuming it will happen in other datasets.
+            if len(label_names) != label(label_sums):
+                logs.warning("Can't make a figure with the given label names: "
+                             "We don't have the right amount of label types "
+                             "to apply them to!")
+                return False
             fig_labels = px.pie(names=label_names, values=label_sums)
     except KeyError:
         logs.info("Input label data missing required key(s).")

--- a/run_data_measurements.py
+++ b/run_data_measurements.py
@@ -96,12 +96,16 @@ def load_or_prepare(dataset_args, calculation=False, use_cache=False):
 
     if do_all or calculation == "labels":
         logs.info("\n* Calculating label statistics.")
-        dstats.load_or_prepare_labels()
-        npmi_fid_dict = dstats.label_files
-        print("If all went well, then results are in the following files:")
-        for key, value in npmi_fid_dict.items():
-            print("%s: %s" % (key, value))
-        print()
+        if dstats.label_field not in dstats.dset:
+            logs.warning("No label field found.")
+            logs.info("No label statistics to calculate.")
+        else:
+            dstats.load_or_prepare_labels()
+            npmi_fid_dict = dstats.label_files
+            print("If all went well, then results are in the following files:")
+            for key, value in npmi_fid_dict.items():
+                print("%s: %s" % (key, value))
+            print()
 
     if do_all or calculation == "npmi":
         print("\n* Preparing nPMI.")


### PR DESCRIPTION
Handling the case where labels statistics are asked for, but a label column isn't there.  (This used to be handled but in the recent code refactors got lost.). 
Also adding catch when the number of label types observed is not equal to the number of label types are are given.
See: https://github.com/huggingface/data-measurements-tool/issues/42