### PR TITLE
Change mpimg to Image

### DIFF
--- a/data_measurements/lengths/lengths.py
+++ b/data_measurements/lengths/lengths.py
@@ -1,4 +1,5 @@
 import logging
+from PIL import Image
 import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -27,6 +28,7 @@ logs = utils.prepare_logging(__file__)
 def make_fig_lengths(lengths_df):
     # How the hell is this working? plt transforms to sns  ?!
     logs.info("Creating lengths figure.")
+    plt.switch_backend("Agg")
     fig_tok_lengths, axs = plt.subplots(figsize=(15, 6), dpi=150)
     plt.xlabel("Number of tokens")
     plt.title("Binned counts of text lengths, with kernel density estimate and ticks for each instance.")
@@ -108,7 +110,7 @@ class DMTHelper:
             self.lengths_df = ds_utils.read_df(self.lengths_df_json_fid)
         # Image exists. Load it.
         if exists(self.lengths_fig_png_fid):
-            self.fig_lengths = mpimg.imread(self.lengths_fig_png_fid)
+            self.fig_lengths = Image.open(self.lengths_fig_png_fid)
         # Measurements exist. Load them.
         if exists(self.length_stats_json_fid):
             # Loads the length measurements


### PR DESCRIPTION
Running locally, I get 2 errors for the lengths. This PR fixes both.

- A threading error when the image if first created and then "displayed" through gradio. It doesn't get displayed, it gives an error. This is fixed with `plt.switch_backend("Agg")`, following the same error as detailed in https://stackoverflow.com/questions/63412583/nswindow-drag-regions-should-only-be-invalidated-on-the-main-thread-this-will-t

- The following error when I load the UI. 

```
Traceback (most recent call last):
  File "/opt/anaconda3/lib/python3.9/site-packages/gradio/routes.py", line 292, in run_predict
    output = await app.blocks.process_api(
  File "/opt/anaconda3/lib/python3.9/site-packages/gradio/blocks.py", line 1008, in process_api
    data = self.postprocess_data(fn_index, result["prediction"], state)
  File "/opt/anaconda3/lib/python3.9/site-packages/gradio/blocks.py", line 954, in postprocess_data
    prediction_value = block.postprocess(prediction_value)
  File "/opt/anaconda3/lib/python3.9/site-packages/gradio/components.py", line 1429, in postprocess
    raise ValueError("Cannot process this value as an Image")
ValueError: Cannot process this value as an Image
```
