### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check_size.yaml
+++ b/.github/workflows/check_size.yaml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check large files
-        uses: ActionsDesk/lfs-warning@v2.0
+        uses: ActionsDesk/lfs-warning@1a3a74543c2cf92cc97aa1bad190a500bcb3829c  # v2.0
         with:
           filesizelimit: 10485760 # = 10MB, so we can sync to HF spaces


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `check_size.yaml` | `ActionsDesk/lfs-warning` | `v2.0` | `v2.0` | `1a3a74543c2c…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#88